### PR TITLE
Fix data race

### DIFF
--- a/lantern/local.go
+++ b/lantern/local.go
@@ -205,12 +205,10 @@ func (l *lduplex) CloseRead() error {
 	return l.Conn.Close()
 }
 
-// this is triggered when a client finishes writing,
-// it is handled as a no-op, we just ignore it since
-// we don't depend on half closing the connection to
-// signal anything.
+// this is triggered when a client finishes writing.
+// This triggers a close of both ends.
 func (l *lduplex) CloseWrite() error {
-	return nil
+	return l.Conn.Close()
 }
 
 // this is an adapter that forwards the remote address

--- a/service/tcp.go
+++ b/service/tcp.go
@@ -279,8 +279,7 @@ func (s *tcpService) handleConnection(listenerPort int, clientTCPConn *net.TCPCo
 		ssw := ss.NewShadowsocksWriter(clientConn, cipherEntry.Cipher)
 		ssw.SetSaltGenerator(cipherEntry.SaltGenerator)
 
-		fromClientErrCh := make(chan error, 1)
-		fromTargetErrCh := make(chan error, 1)
+		fromClientErrCh := make(chan error)
 		go func() {
 			_, fromClientErr := ssr.WriteTo(tgtConn)
 			if fromClientErr != nil {
@@ -294,27 +293,19 @@ func (s *tcpService) handleConnection(listenerPort int, clientTCPConn *net.TCPCo
 			tgtConn.CloseWrite()
 			fromClientErrCh <- fromClientErr
 		}()
+		_, fromTargetErr := ssw.ReadFrom(tgtConn)
+		// Send FIN to client.
+		clientConn.CloseWrite()
+		tgtConn.CloseRead()
 
-		go func() {
-			_, fromTargetErr := ssw.ReadFrom(tgtConn)
-			// Send FIN to client.
-			clientConn.CloseWrite()
-			tgtConn.CloseRead()
-			fromTargetErrCh <- fromTargetErr
-		}()
-
-		select {
-		case fromClientErr := <-fromClientErrCh:
-			if fromClientErr == nil {
-				return nil
-			}
+		fromClientErr := <-fromClientErrCh
+		if fromClientErr != nil {
 			return onet.NewConnectionError("ERR_RELAY_CLIENT", "Failed to relay traffic from client", fromClientErr)
-		case fromTargetErr := <-fromClientErrCh:
-			if fromTargetErr == nil {
-				return nil
-			}
+		}
+		if fromTargetErr != nil {
 			return onet.NewConnectionError("ERR_RELAY_TARGET", "Failed to relay traffic from target", fromTargetErr)
 		}
+		return nil
 	}()
 
 	connDuration := time.Now().Sub(connStart)


### PR DESCRIPTION
This is actually a re-do of https://github.com/getlantern/lantern-shadowsocks/pull/6.  This PR reverts the changes made by https://github.com/getlantern/lantern-shadowsocks/pull/6 and uses a new fix instead (the one suggested by @forkner [here](https://github.com/getlantern/lantern-shadowsocks/pull/6#issuecomment-854057542)).  To ensure that the new fix still addresses the leak, I modified an existing test to trigger the leak.  You can check out [this commit](https://github.com/getlantern/lantern-shadowsocks/commit/62b1350189951cb3332489830623cd6a061d91e8) and run `go test ./lantern` to see the leak.  Running `go test ./lantern` or `go test ./...` on this branch will demonstrate that the leak is still fixed (and that all other tests still pass).

The reason for the re-do is that the original fix created a data race regarding the metrics.ProxyMetrics instance associated with each handled connection. The bidirectional-copy goroutines ([these ones](https://github.com/getlantern/lantern-shadowsocks/blob/e04471aa4920f38c7f10e5f82e17b726658562ad/service/tcp.go#L284-L304)) could still be running and [writing to the metrics](https://github.com/getlantern/lantern-shadowsocks/blob/e04471aa4920f38c7f10e5f82e17b726658562ad/service/tcp.go#L236) when the metrics are [read and passed to the caller-provided metrics.ShadowsocksMetrics instance](https://github.com/getlantern/lantern-shadowsocks/blob/e04471aa4920f38c7f10e5f82e17b726658562ad/service/tcp.go#L330).  To see this data race, check out `master` and run `go test -race ./service`.

An alternative solution would be to use a `sync.WaitGroup` or similar to wait for both copying goroutines to exit.  However, this solution seems simpler and results in less overall changes to the upstream.

This is all a yak-shave for https://github.com/getlantern/lantern-desktop/pull/174 =)