### PR TITLE
Add custom prefix support

### DIFF
--- a/prefix/customprefix/builtins.go
+++ b/prefix/customprefix/builtins.go
@@ -1,0 +1,167 @@
+package customprefix
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+)
+
+const defaultRandomStringSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+type builtin func([]string) ([]byte, error)
+
+// Builtins is a collection of built-in functions which can be referenced in the specifier provided
+// to NewCustomPrefix.
+var Builtins = map[string]builtin{
+	"hex":           Hex,
+	"random_string": RandomString,
+	"random_int":    RandomInt,
+	"random_bytes":  RandomBytes,
+}
+
+var mathrand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// Hex is a builtin function (see New and Builtins).
+//
+// Args:
+//
+//	0 (hex input): string
+//		even in length, containing only characters in [0-9A-Fa-f]
+//
+// Parses argument 0 into raw bytes and prints to the output.
+//
+// Example:
+//
+//	$hex(BEEFFACE33)
+func Hex(args []string) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("expected 1 arg, received %d", len(args))
+	}
+	return hex.DecodeString(args[0])
+}
+
+// RandomString is a builtin function (see New and Builtins).
+//
+// Args:
+//
+//	0 (min length): integer
+//	1 (max length): integer
+//	2 (character set): string, optional
+//
+// Produces a string, whose length will be [min length, max length). If a character set is provided,
+// only the specified characters will be considered. The default character set is the set of 26
+// alphabetic characters, lower and upper case.
+//
+// Examples:
+//
+//	$random_string(1, 10)
+//	$random_string(1, 10, aeiou)
+func RandomString(args []string) ([]byte, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("expected at least 2 args, received %d", len(args))
+	}
+
+	minLen, err := strconv.Atoi(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse min len: %w", err)
+	}
+	maxLen, err := strconv.Atoi(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse max len: %w", err)
+	}
+
+	chars := []rune(defaultRandomStringSet)
+	if len(args) > 2 {
+		chars = []rune(args[2])
+	}
+
+	runes := make([]rune, mathrand.Intn(maxLen-minLen)+minLen)
+	for i := range runes {
+		runes[i] = chars[mathrand.Intn(len(chars))]
+	}
+	return []byte(string(runes)), nil
+}
+
+// RandomInt is a builtin function (see New and Builtins).
+//
+// Args:
+//
+//	0 (min): integer
+//	1 (max): integer
+//
+// Produces an integer in the range [min, max).
+//
+// Examples:
+//
+//	$random_int(0, 10)
+//	$random_int(-1000, 1000)
+func RandomInt(args []string) ([]byte, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("expected 2 args, received %d", len(args))
+	}
+
+	minLen, err := strconv.Atoi(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse min len: %w", err)
+	}
+	maxLen, err := strconv.Atoi(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse max len: %w", err)
+	}
+
+	n := mathrand.Intn(maxLen-minLen) + minLen
+	return []byte(strconv.Itoa(n)), nil
+}
+
+// RandomBytes is a builtin function (see New and Builtins).
+//
+// Args:
+//
+//	0 (min length): integer
+//	1 (max length): integer
+//	2 (byte set): string, optional
+//		even in length, containing only characters in [0-9A-Fa-f]
+//		each group of two characters represents a possible choice
+//
+// Produces a byte string, whose length will be [min length, max length). If a byte set is provided,
+// only the specified bytes will be considered. The default byte set is all possible bytes.
+//
+// Examples:
+//
+//	$random_bytes(1, 10)
+//	$random_bytes(1, 10, 010203A1A2A3)
+func RandomBytes(args []string) ([]byte, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("expected at least 2 args, received %d", len(args))
+	}
+
+	minLen, err := strconv.Atoi(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse min len: %w", err)
+	}
+	maxLen, err := strconv.Atoi(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse max len: %w", err)
+	}
+
+	var possibilities []byte
+	if len(args) > 2 {
+		possibilities, err = hex.DecodeString(args[2])
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode byte set")
+		}
+	} else {
+		possibilities = make([]byte, 256)
+		for i := 0; i < 256; i++ {
+			possibilities[i] = byte(i)
+		}
+	}
+
+	b := make([]byte, mathrand.Intn(maxLen-minLen)+minLen)
+	for i := range b {
+		b[i] = possibilities[mathrand.Intn(len(possibilities))]
+	}
+	return b, nil
+}

--- a/prefix/customprefix/builtins_test.go
+++ b/prefix/customprefix/builtins_test.go
@@ -1,0 +1,75 @@
+package customprefix
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuiltins tests parsing and execution of built-in functions. We test built-ins through the
+// parser to ensure end-to-end testing of argument parsing. More thorough testing of the parser is
+// left to TestParser.
+func TestBuiltins(t *testing.T) {
+	generate := func(t *testing.T, generator string) []byte {
+		t.Helper()
+
+		genFunc, err := parse(generator, Builtins)
+		require.NoError(t, err)
+
+		out, err := genFunc()
+		require.NoError(t, err)
+
+		return out
+	}
+
+	t.Run("hex", func(t *testing.T) {
+		out := generate(t, `v1.0 $hex(1a2b3cBEEF)`)
+		require.Equal(t, []byte{0x1a, 0x2b, 0x3c, 0xbe, 0xef}, out)
+	})
+
+	t.Run("random_string", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			out := string(generate(t, `v1.0 $random_string(1, 10)`))
+			require.GreaterOrEqual(t, len(out), 1)
+			require.Less(t, len(out), 10)
+		}
+	})
+
+	t.Run("random_string/custom_set", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			out := string(generate(t, `v1.0 $random_string(1, 10, aeiou)`))
+			for _, r := range out {
+				require.Contains(t, []rune("aeiou"), r)
+			}
+		}
+	})
+
+	t.Run("random_int", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			out := generate(t, `v1.0 $random_int(-10, 10)`)
+
+			n, err := strconv.Atoi(string(out))
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, n, -10)
+			require.Less(t, n, 10)
+		}
+	})
+
+	t.Run("random_bytes", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			out := generate(t, `v1.0 $random_bytes(1, 10)`)
+			require.GreaterOrEqual(t, len(out), 1)
+			require.Less(t, len(out), 10)
+		}
+	})
+
+	t.Run("random_bytes/custom_set", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			out := generate(t, `v1.0 $random_bytes(1, 10, 010203A1A2A3)`)
+			for _, b := range out {
+				require.Contains(t, []byte{0x01, 0x02, 0x03, 0xa1, 0xa2, 0xa3}, b)
+			}
+		}
+	})
+}

--- a/prefix/customprefix/customprefix.go
+++ b/prefix/customprefix/customprefix.go
@@ -1,0 +1,57 @@
+// Package customprefix defines a prefix.Prefix type based on custom specifiers.
+package customprefix
+
+// CustomPrefix implements the prefix.Prefix interface using a custom specifier. See New for more
+// details.
+type CustomPrefix struct {
+	// The generator program provided to New, parsed into a Go function.
+	generator func() ([]byte, error)
+}
+
+// New creates a new Prefix based on a generator. The generator is a rudimentary program, with a
+// grammar defined in EBNF as:
+//
+//	letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
+//	  | "H" | "I" | "J" | "K" | "L" | "M" | "N"
+//	  | "O" | "P" | "Q" | "R" | "S" | "T" | "U"
+//	  | "V" | "W" | "X" | "Y" | "Z" | "a" | "b"
+//	  | "c" | "d" | "e" | "f" | "g" | "h" | "i"
+//	  | "j" | "k" | "l" | "m" | "n" | "o" | "p"
+//	  | "q" | "r" | "s" | "t" | "u" | "v" | "w"
+//	  | "x" | "y" | "z" ;
+//	digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+//	whitespace = " " | "\t" | "\n" | "\r" ;
+//	char = letter | digit | whitespace
+//
+//	number = digit, { digit } ;
+//	string = char, { char } ;
+//	identifier = letter, { letter | "_" } ;
+//
+//	version = "v", number , ".", number ;
+//	arg list = string, { ",", " ", string } ;
+//	function call = "$", identifier, "(", [ arg list ], ")" ;
+//
+//	generator = version, " ", { string | whitespace | function call }
+//
+// where the function calls reference a limited set of built-in functions defined in Builtins.
+// Nested function calls are not supported.
+//
+// Generators begin with a version specifier. This specifier is used to make parsing decisions, but
+// is left out of the output prefix.
+//
+// Example generators:
+//
+//	httpGet = `v1.0 GET /$random_string(5, 10) HTTP/1.1`
+//
+//	dnsOverTCP = `v1.0 $hex(05DC)$random_bytes(2, 3)$hex(0120)`
+func New(generator string) (*CustomPrefix, error) {
+	genFunc, err := parse(generator, Builtins)
+	if err != nil {
+		return nil, err
+	}
+	return &CustomPrefix{genFunc}, nil
+}
+
+func (p *CustomPrefix) Make() ([]byte, error) {
+	return p.generator()
+}

--- a/prefix/customprefix/parser.go
+++ b/prefix/customprefix/parser.go
@@ -1,0 +1,99 @@
+package customprefix
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// currentMajorVersion defines the current major version of the custom prefix specification.
+const currentMajorVersion = 1
+
+var (
+	generatorRegexp    = regexp.MustCompile(`^v([0-9]+)\.([0-9]+) ([\s\S]*)$`)
+	functionCallRegexp = regexp.MustCompile(`\$([a-zA-Z][a-zA-Z_]*)\(([^\)]*)\)`)
+)
+
+// parse parses a generator as defined by New and returns a Go function implementing the generator.
+func parse(generator string, builtins map[string]builtin) (func() ([]byte, error), error) {
+	matches := generatorRegexp.FindStringSubmatch(generator)
+	if len(matches) != 4 {
+		return nil, errors.New("malformed version specifier")
+	}
+
+	// n.b. We can ignore the error because of the regular expression.
+	majorVersion, _ := strconv.Atoi(matches[1])
+	if majorVersion > currentMajorVersion {
+		return nil, fmt.Errorf(
+			"major version %d exceeds supported version %d", majorVersion, currentMajorVersion)
+	}
+
+	// Parse out all function calls.
+
+	generator = matches[3]
+	rawFunctionCalls := functionCallRegexp.FindAllString(generator, -1)
+
+	// Collect a slice of unevaluated function calls (parse the functions and their args, but do not
+	// yet evaluate).
+
+	type functionCall struct {
+		name string
+		eval func() ([]byte, error)
+	}
+
+	functionCalls := make([]functionCall, len(rawFunctionCalls))
+	for i, call := range rawFunctionCalls {
+		submatches := functionCallRegexp.FindStringSubmatch(call)
+		if len(submatches) != 3 {
+			return nil, errors.New("malformed function call")
+		}
+
+		name, rawArgs := submatches[1], submatches[2]
+		f, ok := builtins[name]
+		if !ok {
+			return nil, fmt.Errorf("unsupported builtin '%s'", name)
+		}
+		if strings.Contains(rawArgs, "$") {
+			return nil, fmt.Errorf("nested functions are not supported")
+		}
+
+		args := strings.Split(rawArgs, ",")
+		if len(args) == 1 && args[0] == "" {
+			args = []string{}
+		}
+		for i, arg := range args {
+			args[i] = strings.TrimSpace(arg)
+		}
+
+		functionCalls[i] = functionCall{
+			name: name,
+			eval: func() ([]byte, error) {
+				return f(args)
+			},
+		}
+	}
+
+	// When we are called to generate the prefix, evaluate all function calls. This ensures that
+	// non-deterministic functions are re-evaluated each time.
+	return func() ([]byte, error) {
+		functionResults := make([][]byte, len(functionCalls))
+		for i, call := range functionCalls {
+			res, err := call.eval()
+			if err != nil {
+				return nil, fmt.Errorf("%s: %s", call.name, err)
+			}
+			functionResults[i] = res
+		}
+
+		replaceIndex := 0
+		replaceFunc := func(_ []byte) []byte {
+			replace := functionResults[replaceIndex]
+			replaceIndex++
+			return replace
+		}
+
+		return functionCallRegexp.ReplaceAllFunc([]byte(generator), replaceFunc), nil
+	}, nil
+}

--- a/prefix/customprefix/parser_test.go
+++ b/prefix/customprefix/parser_test.go
@@ -1,0 +1,264 @@
+package customprefix
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneratorRegexp(t *testing.T) {
+	for _, testCase := range []struct {
+		input, majorVersion, minorVersion, rest string
+		shouldMatch                             bool
+	}{
+		{
+			`v1.0 HTTP/1.1`, `1`, `0`, `HTTP/1.1`, true,
+		},
+		{
+			`v100.100 HTTP/1.1`, `100`, `100`, `HTTP/1.1`, true,
+		},
+		{
+			"v1.0 MyProtocol/v1.0 blah blah $foo(3, 4)\n blah$bar()",
+			"1", "0", "MyProtocol/v1.0 blah blah $foo(3, 4)\n blah$bar()", true,
+		},
+		{
+			`v10 HTTP/1.1`, "", "", "", false,
+		},
+		{
+			`v1.0HTTP/1.1`, "", "", "", false,
+		},
+		{
+			`v1.0`, "", "", "", false,
+		},
+	} {
+		t.Run(testCase.input, func(t *testing.T) {
+			doesMatch := generatorRegexp.MatchString(testCase.input)
+			if !assert.Equal(t, testCase.shouldMatch, doesMatch) || !doesMatch {
+				return
+			}
+
+			submatches := generatorRegexp.FindStringSubmatch(testCase.input)
+			if !assert.Len(t, submatches, 4) {
+				return
+			}
+
+			assert.Equal(t, testCase.majorVersion, submatches[1])
+			assert.Equal(t, testCase.minorVersion, submatches[2])
+			assert.Equal(t, testCase.rest, submatches[3])
+		})
+	}
+}
+
+func TestFunctionCallRegexp(t *testing.T) {
+	t.Run("top level", func(t *testing.T) {
+		for _, testCase := range []struct {
+			input           string
+			expectedMatches []string
+		}{
+			{
+				`HTTP/1.1`, nil,
+			},
+			{
+				"MyProtocol/v1.0 blah blah $foo(3, 4)\n blah$bar()",
+				[]string{`$foo(3, 4)`, `$bar()`},
+			},
+		} {
+			t.Run(testCase.input, func(t *testing.T) {
+				matches := functionCallRegexp.FindAllString(testCase.input, -1)
+				assert.Equal(t, testCase.expectedMatches, matches)
+			})
+		}
+	})
+
+	t.Run("sub match", func(t *testing.T) {
+		for _, testCase := range []struct {
+			input, functionName, args string
+		}{
+			{`$foo(3, 4)`, "foo", "3, 4"},
+			{`$bar()`, "bar", ""},
+		} {
+			t.Run(testCase.input, func(t *testing.T) {
+				submatches := functionCallRegexp.FindStringSubmatch(testCase.input)
+				if !assert.Len(t, submatches, 3) {
+					return
+				}
+
+				assert.Equal(t, testCase.functionName, submatches[1])
+				assert.Equal(t, testCase.args, submatches[2])
+			})
+		}
+	})
+}
+
+func TestParse(t *testing.T) {
+	// A special set of built-ins, designed to test arg parsing, result printing, and errors.
+	builtins := map[string]builtin{
+		"printB": func(args []string) ([]byte, error) {
+			return []byte{'B'}, nil
+		},
+		"printC": func(_ []string) ([]byte, error) {
+			return []byte{'C'}, nil
+		},
+		"printBinaryFF": func(_ []string) ([]byte, error) {
+			return []byte{0xff}, nil
+		},
+		"assertNoArgs": func(args []string) ([]byte, error) {
+			if len(args) != 0 {
+				return nil, fmt.Errorf("expected no args, received %d", len(args))
+			}
+			return []byte{}, nil
+		},
+		"assertNine": func(args []string) ([]byte, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("expected a single argument, received %d", len(args))
+			}
+			if args[0] != "9" {
+				return nil, fmt.Errorf("expected '9' as arg 0, received '%s'", args[0])
+			}
+			return []byte{}, nil
+		},
+		"assertNineAndEleven": func(args []string) ([]byte, error) {
+			if len(args) != 2 {
+				return nil, fmt.Errorf("expected a single argument, received %d", len(args))
+			}
+			if args[0] != "9" {
+				return nil, fmt.Errorf("expected '9' as arg 0, received '%s'", args[0])
+			}
+			if args[1] != "11" {
+				return nil, fmt.Errorf("expected '11' as arg 1, received '%s'", args[1])
+			}
+			return []byte{}, nil
+		},
+		"assertNineNineFACE": func(args []string) ([]byte, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("expected a single argument, received %d", len(args))
+			}
+			if args[0] != "09FACE" {
+				return nil, fmt.Errorf("expected '09FACE' as arg 0, received '%s'", args[0])
+			}
+			return []byte{}, nil
+		},
+		"returnError": func(_ []string) ([]byte, error) {
+			return nil, errors.New("runtime error")
+		},
+	}
+
+	for _, testCase := range []struct {
+		input                                string
+		expectedOutput                       []byte
+		expectParseError, expectRuntimeError bool
+	}{
+		{
+			`v1.0 $printB()`,
+			[]byte("B"), false, false,
+		},
+		{
+			`v1.0 $printB()$printC()`,
+			[]byte("BC"), false, false,
+		},
+		{
+			`v1.0 A$printB()$printC()`,
+			[]byte("ABC"), false, false,
+		},
+		{
+			// n.b. printB ignores its arguments.
+			`v1.0 A$printB(arg1, arg2, arg3)$printC()`,
+			[]byte("ABC"), false, false,
+		},
+		{
+			`v1.0 $printB()$printBinaryFF()`,
+			[]byte{'B', 0xff}, false, false,
+		},
+		{
+			"v1.0 \n$printB()\n$printBinaryFF()\r\n",
+			[]byte{'\n', 'B', '\n', 0xff, '\r', '\n'}, false, false,
+		},
+		{
+			"v1.0 \n$printB()\nSOME TEXT\nA $printB() $printC() D\r\n",
+			[]byte("\nB\nSOME TEXT\nA B C D\r\n"), false, false,
+		},
+		{
+			`v1.0 $assertNoArgs()`,
+			[]byte{}, false, false,
+		},
+		{
+			`v1.0 $assertNine(9)`,
+			[]byte{}, false, false,
+		},
+		{
+			`v1.0 $assertNineAndEleven(9, 11)`,
+			[]byte{}, false, false,
+		},
+		{
+			`v1.0 $assertNineNineFACE(09FACE)`,
+			[]byte{}, false, false,
+		},
+		{
+			`v1.0 $assertNoArgs()$assertNineAndEleven(9, 11)$assertNineNineFACE(09FACE)`,
+			[]byte{}, false, false,
+		},
+		{
+			// Version exceeds supported version.
+			`v999999.0 $printB()$printC()`,
+			nil, true, false,
+		},
+		{
+			// No version specifier.
+			`$printB()$printC()`,
+			nil, true, false,
+		},
+		{
+			// No space after version specifier
+			`v1.0$printB()$printC()`,
+			nil, true, false,
+		},
+		{
+			// Unsupported built-in.
+			`v1.0 $printB()$unsupportedBuiltin()`,
+			nil, true, false,
+		},
+		{
+			// Nested functions are unsupported.
+			// n.b. printB ignores its arguments.
+			`v1.0 $printB($printC())`,
+			nil, true, false,
+		},
+		{
+			// Runtime error returned by built-in.
+			`v1.0 $printB()$printC()$returnError()`,
+			nil, false, true,
+		},
+	} {
+		// t.Run(strconv.Itoa(i), func(t *testing.T) {
+		t.Run(testCase.input, func(t *testing.T) {
+			genFunc, err := parse(testCase.input, builtins)
+			if testCase.expectParseError {
+				assert.Error(t, err)
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			output, err := genFunc()
+			if testCase.expectRuntimeError {
+				assert.Error(t, err)
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Guard against bugs which produce runaway output.
+			if len(output) > 1024 {
+				t.Logf("output length %d exceeds guard; skipping equality check", len(output))
+				t.Fail()
+				return
+			}
+
+			assert.Equal(t, string(testCase.expectedOutput), string(output))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds an implementation of `prefix.Prefix`, with support for dynamic prefix generators.  For example, we could define define the following prefixes:
```
httpGet = `GET /$random_string(5, 10) HTTP/1.1`

dnsOverTCP = `$hex(05DC)$random_bytes(2, 3)$hex(0120)`
```

I'll follow up shortly with separate PRs to flashlight and lantern-infrastructure, adding support for a new config parameter, `shadowsocks_custom_prefix_generator`, allowing us to send generators like those above to clients.  But the meat of the new functionality is in this PR.

Generators are rudimentary programs, with a few built-in functions to support randomness and raw bytes.  The generator parser is versioned, allowing the possibility of backwards-compatible updates.

In the future, I'd like to add a `random_word` built-in.