### PR TITLE
Use interface instead of concrete net.TCPListener type

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ You can do that with this fork like this:
         p := prefix.FromString("dnsovertcp")
 	      cl.SetTCPSaltGenerator(NewPrefixSaltGenerator(p.Make))
 
-No service-side change is required but **make sure** the prefix is not too big since you're lowering the security of the encryption. See here: https://github.com/getlantern/lantern-shadowsocks/blob/ee3db22b920c79c4c5bc5c97892c7cd1d8a91627/client/salt.go#L46
+No service-side change is required but **make sure** the prefix is not too big since you're lowering the security of the encryption. See here: https://github.com/getlantern-lantern-shadowsocks/blob/ee3db22b920c79c4c5bc5c97892c7cd1d8a91627/client/salt.go#L46
 
 There's a specific prefix we use for some Iranian tracks in `prefix/dnsovertcp.go`.
 

--- a/client/client.go
+++ b/client/client.go
@@ -23,7 +23,7 @@ type Client interface {
 	// DialTCP connects to `raddr` over TCP though a Shadowsocks proxy.
 	// `laddr` is a local bind address, a local address is automatically chosen if nil.
 	// `raddr` has the form `host:port`, where `host` can be a domain name or IP address.
-	DialTCP(laddr *net.TCPAddr, raddr string) (onet.DuplexConn, error)
+	DialTCP(laddr *net.TCPAddr, raddr string) (onet.TCPConn, error)
 
 	// ListenUDP relays UDP packets though a Shadowsocks proxy.
 	// `laddr` is a local bind address, a local address is automatically chosen if nil.
@@ -75,7 +75,7 @@ func (c *ssClient) SetTCPSaltGenerator(salter ss.SaltGenerator) {
 // was ~1 ms.)  If no client payload is received by this time, we connect without it.
 const helloWait = 10 * time.Millisecond
 
-func (c *ssClient) DialTCP(laddr *net.TCPAddr, raddr string) (onet.DuplexConn, error) {
+func (c *ssClient) DialTCP(laddr *net.TCPAddr, raddr string) (onet.TCPConn, error) {
 	socksTargetAddr := socks.ParseAddr(raddr)
 	if socksTargetAddr == nil {
 		return nil, errors.New("Failed to parse target address")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/getlantern/lantern-shadowsocks
+module github.com/Jigsaw-Code/outline-ss-server
 
 go 1.18
 

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -113,7 +113,7 @@ func TestTCPEcho(t *testing.T) {
 	const testTimeout = 200 * time.Millisecond
 	proxy := service.NewTCPService(cipherList, &replayCache, &metrics.NoOpMetrics{}, testTimeout)
 	proxy.SetTargetIPValidator(allowAll)
-	go proxy.Serve(proxyListener)
+	go proxy.Serve(onet.AdaptListener(proxyListener))
 
 	proxyHost, proxyPort, err := net.SplitHostPort(proxyListener.Addr().String())
 	if err != nil {
@@ -185,7 +185,7 @@ func TestRestrictedAddresses(t *testing.T) {
 	const testTimeout = 200 * time.Millisecond
 	testMetrics := &statusMetrics{}
 	proxy := service.NewTCPService(cipherList, nil, testMetrics, testTimeout)
-	go proxy.Serve(proxyListener)
+	go proxy.Serve(onet.AdaptListener(proxyListener))
 
 	proxyHost, proxyPort, err := net.SplitHostPort(proxyListener.Addr().String())
 	require.NoError(t, err)
@@ -365,7 +365,7 @@ func BenchmarkTCPThroughput(b *testing.B) {
 	const testTimeout = 200 * time.Millisecond
 	proxy := service.NewTCPService(cipherList, nil, &metrics.NoOpMetrics{}, testTimeout)
 	proxy.SetTargetIPValidator(allowAll)
-	go proxy.Serve(proxyListener)
+	go proxy.Serve(onet.AdaptListener(proxyListener))
 
 	proxyHost, proxyPort, err := net.SplitHostPort(proxyListener.Addr().String())
 	if err != nil {
@@ -432,7 +432,7 @@ func BenchmarkTCPMultiplexing(b *testing.B) {
 	const testTimeout = 200 * time.Millisecond
 	proxy := service.NewTCPService(cipherList, &replayCache, &metrics.NoOpMetrics{}, testTimeout)
 	proxy.SetTargetIPValidator(allowAll)
-	go proxy.Serve(proxyListener)
+	go proxy.Serve(onet.AdaptListener(proxyListener))
 
 	proxyHost, proxyPort, err := net.SplitHostPort(proxyListener.Addr().String())
 	if err != nil {

--- a/net/net.go
+++ b/net/net.go
@@ -5,9 +5,8 @@ import (
 	"net"
 )
 
-// DuplexConn is a net.Conn that allows for closing only the reader or writer end of
-// it, supporting half-open state.
-type DuplexConn interface {
+// TCPConn is an interface for conns that expose specific functionality from net.TCPConn
+type TCPConn interface {
 	net.Conn
 	// Closes the Read end of the connection, allowing for the release of resources.
 	// No more reads should happen.
@@ -15,45 +14,47 @@ type DuplexConn interface {
 	// Closes the Write end of the connection. An EOF or FIN signal may be
 	// sent to the connection target.
 	CloseWrite() error
+	// Like SetKeepAlive from net.TCPConn
+	SetKeepAlive(bool) error
 }
 
-type duplexConnAdaptor struct {
-	DuplexConn
+type tcpConnAdaptor struct {
+	TCPConn
 	r io.Reader
 	w io.Writer
 }
 
-func (dc *duplexConnAdaptor) Read(b []byte) (int, error) {
+func (dc *tcpConnAdaptor) Read(b []byte) (int, error) {
 	return dc.r.Read(b)
 }
-func (dc *duplexConnAdaptor) WriteTo(w io.Writer) (int64, error) {
+func (dc *tcpConnAdaptor) WriteTo(w io.Writer) (int64, error) {
 	return io.Copy(w, dc.r)
 }
-func (dc *duplexConnAdaptor) CloseRead() error {
-	return dc.DuplexConn.CloseRead()
+func (dc *tcpConnAdaptor) CloseRead() error {
+	return dc.TCPConn.CloseRead()
 }
-func (dc *duplexConnAdaptor) Write(b []byte) (int, error) {
+func (dc *tcpConnAdaptor) Write(b []byte) (int, error) {
 	return dc.w.Write(b)
 }
-func (dc *duplexConnAdaptor) ReadFrom(r io.Reader) (int64, error) {
+func (dc *tcpConnAdaptor) ReadFrom(r io.Reader) (int64, error) {
 	return io.Copy(dc.w, r)
 }
-func (dc *duplexConnAdaptor) CloseWrite() error {
-	return dc.DuplexConn.CloseWrite()
+func (dc *tcpConnAdaptor) CloseWrite() error {
+	return dc.TCPConn.CloseWrite()
 }
 
 // WrapDuplexConn wraps an existing DuplexConn with new Reader and Writer, but
 // preserving the original CloseRead() and CloseWrite().
-func WrapConn(c DuplexConn, r io.Reader, w io.Writer) DuplexConn {
+func WrapConn(c TCPConn, r io.Reader, w io.Writer) TCPConn {
 	conn := c
 	// We special-case duplexConnAdaptor to avoid multiple levels of nesting.
-	if a, ok := c.(*duplexConnAdaptor); ok {
-		conn = a.DuplexConn
+	if a, ok := c.(*tcpConnAdaptor); ok {
+		conn = a.TCPConn
 	}
-	return &duplexConnAdaptor{DuplexConn: conn, r: r, w: w}
+	return &tcpConnAdaptor{TCPConn: conn, r: r, w: w}
 }
 
-func copyOneWay(leftConn, rightConn DuplexConn) (int64, error) {
+func copyOneWay(leftConn, rightConn TCPConn) (int64, error) {
 	n, err := io.Copy(leftConn, rightConn)
 	// Send FIN to indicate EOF
 	leftConn.CloseWrite()
@@ -66,7 +67,7 @@ func copyOneWay(leftConn, rightConn DuplexConn) (int64, error) {
 // bytes copied from right to left, from left to right, and any error occurred.
 // Relay allows for half-closed connections: if one side is done writing, it can
 // still read all remaining data from its peer.
-func Relay(leftConn, rightConn DuplexConn) (int64, int64, error) {
+func Relay(leftConn, rightConn TCPConn) (int64, int64, error) {
 	type res struct {
 		N   int64
 		Err error
@@ -96,4 +97,27 @@ type ConnectionError struct {
 
 func NewConnectionError(status, message string, cause error) *ConnectionError {
 	return &ConnectionError{Status: status, Message: message, Cause: cause}
+}
+
+// Interface for something like net.TCPListener but not using the concrete type.
+type TCPListener interface {
+	net.Listener
+
+	AcceptTCP() (TCPConn, error)
+
+	Close() error
+
+	Addr() net.Addr
+}
+
+type tcpDuplexListenerAdapter struct {
+	*net.TCPListener
+}
+
+func (l *tcpDuplexListenerAdapter) AcceptTCP() (TCPConn, error) {
+	return l.TCPListener.AcceptTCP()
+}
+
+func AdaptListener(l *net.TCPListener) TCPListener {
+	return &tcpDuplexListenerAdapter{l}
 }

--- a/server.go
+++ b/server.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 	"time"
 
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	"github.com/Jigsaw-Code/outline-ss-server/service"
 	"github.com/Jigsaw-Code/outline-ss-server/service/metrics"
 	ss "github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
@@ -89,7 +90,7 @@ func (s *SSServer) startPort(portNum int) error {
 	port.tcpService = service.NewTCPService(port.cipherList, &s.replayCache, s.m, tcpReadTimeout)
 	port.udpService = service.NewUDPService(s.natTimeout, port.cipherList, s.m)
 	s.ports[portNum] = port
-	go port.tcpService.Serve(listener)
+	go port.tcpService.Serve(onet.AdaptListener(listener))
 	go port.udpService.Serve(packetConn)
 	return nil
 }

--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -295,7 +295,7 @@ func (m *ProxyMetrics) add(other ProxyMetrics) {
 }
 
 type measuredConn struct {
-	onet.DuplexConn
+	onet.TCPConn
 	io.WriterTo
 	readCount *int64
 	io.ReaderFrom
@@ -303,31 +303,31 @@ type measuredConn struct {
 }
 
 func (c *measuredConn) Read(b []byte) (int, error) {
-	n, err := c.DuplexConn.Read(b)
+	n, err := c.TCPConn.Read(b)
 	*c.readCount += int64(n)
 	return n, err
 }
 
 func (c *measuredConn) WriteTo(w io.Writer) (int64, error) {
-	n, err := io.Copy(w, c.DuplexConn)
+	n, err := io.Copy(w, c.TCPConn)
 	*c.readCount += n
 	return n, err
 }
 
 func (c *measuredConn) Write(b []byte) (int, error) {
-	n, err := c.DuplexConn.Write(b)
+	n, err := c.TCPConn.Write(b)
 	*c.writeCount += int64(n)
 	return n, err
 }
 
 func (c *measuredConn) ReadFrom(r io.Reader) (int64, error) {
-	n, err := io.Copy(c.DuplexConn, r)
+	n, err := io.Copy(c.TCPConn, r)
 	*c.writeCount += n
 	return n, err
 }
 
-func MeasureConn(conn onet.DuplexConn, bytesSent, bytesReceived *int64) onet.DuplexConn {
-	return &measuredConn{DuplexConn: conn, writeCount: bytesSent, readCount: bytesReceived}
+func MeasureConn(conn onet.TCPConn, bytesSent, bytesReceived *int64) onet.TCPConn {
+	return &measuredConn{TCPConn: conn, writeCount: bytesSent, readCount: bytesReceived}
 }
 
 // NoOpMetrics is a fake ShadowsocksMetrics that doesn't do anything. Useful in tests


### PR DESCRIPTION
This is needed so that http-proxy-lantern can get access to the underlying client connection, useful for example for exposing BBR metrics.